### PR TITLE
add keycodes for AZERTY keyboard and German umlauts, fix #1

### DIFF
--- a/src/js/app.react.js
+++ b/src/js/app.react.js
@@ -24,7 +24,7 @@ React.render(
 );
 
 React.render(
-  <ChordElement name="vi"  keyName="w" />,
+  <ChordElement name="vi"  keyName="w/z" />,
   document.getElementById('vi-chord')
 );
 React.render(
@@ -64,7 +64,7 @@ React.render(
   document.getElementById('5-note')
 );
 React.render(
-  <NoteElement name="6" keyName=";" />,
+  <NoteElement name="6" keyName=";/ö/m" />,
   document.getElementById('6-note')
 );
 

--- a/src/js/stores/key_store.js
+++ b/src/js/stores/key_store.js
@@ -5,20 +5,23 @@ var assign       = require('object-assign');
 
 var CHANGE_EVENT   = 'change';
 var eventTypeForCode = {
-  '83':  'I',
-  '68':  'IV',
-  '70':  'V',
-  '87':  'vi',
-  '69':  'ii',
-  '82':  'iii',
-  '85':  'Organ',
-  '73':  '8-Bit',
-  '32':  '1',
-  '74':  '2',
-  '75':  '3',
-  '76':  '5',
-  '59':  '6',
-  '186': '6'
+  '83':  'I',     // s
+  '68':  'IV',    // d
+  '70':  'V',     // f
+  '87':  'vi',    // w
+  '122': 'vi',    // z
+  '69':  'ii',    // e
+  '82':  'iii',   // r
+  '85':  'Organ', // u
+  '73':  '8-Bit', // i
+  '32':  '1',     // spacebar
+  '74':  '2',     // j
+  '75':  '3',     // k
+  '76':  '5',     // l
+  '59':  '6',     // ; (Firefox)
+  '186': '6',     // ;
+  '109': '6',     // m
+  '0':   '6'      // ö (German umlauts not correctly recognized)
 };
 var state = {};
 


### PR DESCRIPTION
Fix #1, please review @PoroCYon @billgathen 

The ö wasn’t really possible to catch so it’s a small hack. Just check at this [Keycode test page](http://www.asquare.net/javascript/tests/KeyCode.html), the results are like this for a normal letter:
![l](https://cloud.githubusercontent.com/assets/925062/11336879/2f66ec84-91e9-11e5-8c15-07fbd0dfbc99.png)
And this for ö
![ö](https://cloud.githubusercontent.com/assets/925062/11336878/2f644c4a-91e9-11e5-95ef-0180bf0c6ab7.png)
Basically this means that ä and ü are also caught by this, which I don’t really consider a problem.
