### PR TITLE
add scripts and default task so JS is correctly bundled

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,3 +39,10 @@ gulp.task('styles', function() {
     .pipe(gulp.dest('./dist/styles'))
     .pipe(notify({ message: 'Styles copied' }));
 });
+
+gulp.task('scripts', function() {
+  bundle();
+});
+
+// Default task
+gulp.task('default', ['html', 'styles', 'scripts', 'watch']);


### PR DESCRIPTION
There was no default task set, so simply running `gulp` wasn’t possible. Also, gulp watch only bundled the JS when it was changed on runtime it seems.

@billgathen please review. I know you put the compiled code in the repo, but I didn’t compile (also for the other pull request) just to be able to see the changes better.
